### PR TITLE
Feat: 스터디 조회(필터,전체, 세부) api 기능 추가

### DIFF
--- a/src/main/java/com/sweetme/back/auth/dto/UserDTO.java
+++ b/src/main/java/com/sweetme/back/auth/dto/UserDTO.java
@@ -1,0 +1,26 @@
+package com.sweetme.back.auth.dto;
+
+import com.sweetme.back.auth.domain.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDTO {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    // 필요한 기본적인 사용자 정보만 포함
+    // 비밀번호와 같은 민감한 정보는 제외
+
+    public static UserDTO from(User user) {
+        if (user == null) return null;
+
+        UserDTO dto = new UserDTO();
+        dto.setId(user.getId());
+        dto.setEmail(user.getEmail());
+        dto.setNickname(user.getNickname());
+        return dto;
+    }
+}

--- a/src/main/java/com/sweetme/back/studygroup/controller/StudyController.java
+++ b/src/main/java/com/sweetme/back/studygroup/controller/StudyController.java
@@ -3,17 +3,22 @@ package com.sweetme.back.studygroup.controller;
 import com.sweetme.back.common.domain.BaseEntity;
 import com.sweetme.back.studygroup.domain.Study;
 import com.sweetme.back.studygroup.dto.StudyCreateRequest;
+import com.sweetme.back.studygroup.dto.StudyDetailDTO;
+import com.sweetme.back.studygroup.dto.StudySearchRequest;
 import com.sweetme.back.studygroup.repository.StudyRepository;
 import com.sweetme.back.studygroup.service.StudyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.swing.text.html.HTML;
+import java.util.List;
+import java.util.stream.Collectors;
 
 //@Tag(name = "Study", description = "스터디 관련 API")
 @RestController
@@ -22,7 +27,48 @@ import javax.swing.text.html.HTML;
 public class StudyController {
     private final StudyService studyService;
 
-    @Operation(summary = "스터디 생성", description = "새로운 스터디를 생성합니다.")
+    // 스터디 목록 조회 (검색/필터링)
+    @GetMapping
+    public ResponseEntity<Page<StudyDetailDTO>> getStudies(
+            @RequestParam(defaultValue = "1") int page, // 1부터 시작
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        // 내부적으로는 0부터 시작하므로 1을 빼줌
+        StudySearchRequest request = new StudySearchRequest();
+        request.setPage(page - 1); // 1을 빼서 0부터 시작하게 변환
+        request.setSize(size);
+
+        Page<Study> studies = studyService.getStudies(request);
+        Page<StudyDetailDTO> response = studies.map(StudyDetailDTO::from);
+        return ResponseEntity.ok(response);
+    }
+
+    // 모든 스터디 조회
+    @GetMapping("/all")
+    public ResponseEntity<Page<StudyDetailDTO>> getAllStudies(
+            @RequestParam(defaultValue = "1") int page, // 1부터 시작
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        // 내부적으로는 0부터 시작하므로 1을 빼줌
+        StudySearchRequest request = new StudySearchRequest();
+        request.setPage(page - 1); // 1을 빼서 0부터 시작하게 변환
+        request.setSize(size);
+
+        Page<Study> studies = studyService.getAllStudies(request);
+        Page<StudyDetailDTO> response = studies.map(StudyDetailDTO::from);
+        return ResponseEntity.ok(response);
+    }
+
+    // 스터디 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<StudyDetailDTO> getStudy(@PathVariable Long id) {
+        Study study = studyService.getStudy(id);
+        return ResponseEntity.ok(StudyDetailDTO.from(study));
+    }
+
+
+
+//    @Operation(summary = "스터디 생성", description = "새로운 스터디를 생성합니다.")
     @PostMapping
     public ResponseEntity<?> createStudy(@RequestBody @Valid StudyCreateRequest request ){// @Valid로 검증
         Study createdStudy = studyService.createStudy(request);

--- a/src/main/java/com/sweetme/back/studygroup/domain/Location.java
+++ b/src/main/java/com/sweetme/back/studygroup/domain/Location.java
@@ -1,5 +1,6 @@
 package com.sweetme.back.studygroup.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/sweetme/back/studygroup/dto/LocationDTO.java
+++ b/src/main/java/com/sweetme/back/studygroup/dto/LocationDTO.java
@@ -1,0 +1,24 @@
+package com.sweetme.back.studygroup.dto;
+
+import com.sweetme.back.studygroup.domain.Location;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LocationDTO {
+
+    private Long id;
+    private String name;
+    private Location.LocationType type;
+
+    public static LocationDTO from(Location location) {
+        if (location == null) return null;
+
+        LocationDTO dto = new LocationDTO();
+        dto.setId(location.getId());
+        dto.setName(location.getName());
+        dto.setType(location.getType());
+        return dto;
+    }
+}

--- a/src/main/java/com/sweetme/back/studygroup/dto/StudyDetailDTO.java
+++ b/src/main/java/com/sweetme/back/studygroup/dto/StudyDetailDTO.java
@@ -1,0 +1,45 @@
+package com.sweetme.back.studygroup.dto;
+
+import com.sweetme.back.auth.dto.UserDTO;
+import com.sweetme.back.studygroup.domain.Study;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class StudyDetailDTO {
+    private Long id;
+    private String title;
+    private String description;
+    private Boolean isOnline;
+    private Study.StudyType type;
+    private Boolean isOpened;
+    private Byte minCapacity;
+    private Byte maxCapacity;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private LocationDTO location;
+    private Integer views;
+    // User 정보도 DTO로 변환
+    private UserDTO leader;
+
+    public static StudyDetailDTO from(Study study) {
+        StudyDetailDTO dto = new StudyDetailDTO();
+        dto.setId(study.getId());
+        dto.setTitle(study.getTitle());
+        dto.setDescription(study.getDescription());
+        dto.setIsOnline(study.getIsOnline());
+        dto.setType(study.getType());
+        dto.setIsOpened(study.getIsOpened());
+        dto.setMinCapacity(study.getMinCapacity());
+        dto.setMaxCapacity(study.getMaxCapacity());
+        dto.setStartAt(study.getStartAt());
+        dto.setEndAt(study.getEndAt());
+        dto.setViews(study.getViews());
+        dto.setLocation(LocationDTO.from(study.getLocation()));
+        dto.setLeader(UserDTO.from(study.getLeader()));
+        return dto;
+    }
+}

--- a/src/main/java/com/sweetme/back/studygroup/dto/StudySearchRequest.java
+++ b/src/main/java/com/sweetme/back/studygroup/dto/StudySearchRequest.java
@@ -1,0 +1,20 @@
+package com.sweetme.back.studygroup.dto;
+
+import com.sweetme.back.studygroup.domain.Study;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StudySearchRequest {
+
+    private Long locationId; // 지역별 검색
+    private Boolean isOnline; // 온라인 여부로 검색
+    private Study.StudyType type; // 스터디 타입으로 검색
+    private Boolean isOpened; // 현재 운영중인 스터디로 검색
+    private boolean allStudies = false; // 전체 조회 여부 플래그 추가
+
+    //페이징 정보
+    private int page = 0; // jpa 페이징은 0 부터 시작
+    private int size = 10;
+}

--- a/src/main/java/com/sweetme/back/studygroup/repository/StudyRepository.java
+++ b/src/main/java/com/sweetme/back/studygroup/repository/StudyRepository.java
@@ -1,12 +1,73 @@
 package com.sweetme.back.studygroup.repository;
 
 import com.sweetme.back.studygroup.domain.Study;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface StudyRepository extends JpaRepository<Study, Long> {
+
+    /**
+     * 주어진 필터 조건에 맞는 스터디 목록을 페이징하여 조회함.
+     * 연관된 리더와 위치 정보를 함께 조회하여 N+1 문제를 방지
+     *
+     * @param locationId 필터링할 위치 ID (null인 경우 필터링하지 않음)
+     * @param isOnline 온라인/오프라인 여부 (null인 경우 필터링하지 않음)
+     * @param type 스터디 유형(STUDY/PROJECT) (null인 경우 필터링하지 않음)
+     * @param isOpened 모집 상태 (null인 경우 필터링하지 않음)
+     * @param pageable 페이징 정보 (페이지 번호, 크기, 정렬 조건)
+     * @return 필터링된 스터디 목록을 포함한 Page 객체
+     */
+    @Query(
+    value = "select distinct s from Study s " +
+            "left join fetch s.leader " +
+            "left join fetch s.location " +
+            "where (:locationId is NULL OR s.location.id = :locationId) " +
+            "and (:isOnline is null or s.isOnline = :isOnline) " +
+            "and (:type is null or s.type = :type) " +
+            "and (:isOpened is null or s.isOpened = :isOpened)" +
+            "order by s.createdAt DESC",
+    countQuery = "select count(distinct s) from Study s " +
+                "where (:locationId is NULL OR s.location.id = :locationId) " +
+                "and (:isOnline is null or s.isOnline = :isOnline) " +
+                "and (:type is null or s.type = :type) " +
+                "and (:isOpened is null or s.isOpened = :isOpened)"
+    )
+    Page<Study> findStudiesWithFilters(
+            @Param("locationId") Long locationId,
+            @Param("isOnline") Boolean isOnline,
+            @Param("type")Study.StudyType type,
+            @Param("isOpened") Boolean isOpened,
+            Pageable pageable
+            );
+
+    /**
+     * 모든 스터디를 조회하며, 연관된 리더와 위치 정보를 함께 조회 (N+1 문제 방지)
+     * 생성일 기준 내림차순으로 정렬
+     *
+     * @return 모든 스터디 목록
+     */
+    @Query(
+        value = "select distinct s from Study s " +
+            "LEFT join fetch s.leader " +
+            "LEFT join fetch s.location " +
+            "ORDER BY s.createdAt DESC",
+        countQuery = "select count(distinct s) from Study s"
+    )
+    Page<Study> findAllStudies(Pageable pageable);
+
+
+    /**
+     * 스터디 ID로 스터디를 조회하며, 연관된 리더 정보를 함께 조회함. (N+1 문제 방지)
+     *
+     * @param id 조회할 스터디 ID
+     * @return 리더 정보가 포함된 스터디 Optional 객체
+     */
     @Query("select s from Study s join fetch s.leader where s.id = :id")
     Optional<Study> findByIdWithLeader(@Param("id") Long id);
 }

--- a/src/main/java/com/sweetme/back/studygroup/service/StudyService.java
+++ b/src/main/java/com/sweetme/back/studygroup/service/StudyService.java
@@ -4,12 +4,18 @@ import com.sweetme.back.auth.domain.User;
 import com.sweetme.back.studygroup.domain.Location;
 import com.sweetme.back.studygroup.domain.Study;
 import com.sweetme.back.studygroup.dto.StudyCreateRequest;
+import com.sweetme.back.studygroup.dto.StudySearchRequest;
 import com.sweetme.back.studygroup.repository.LocationRepository;
 import com.sweetme.back.studygroup.repository.StudyRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -22,6 +28,48 @@ public class StudyService {
 //    private final PositionRepository positionRepository;
 //    private final StackRepository stackRepository;
 //    private final ChatService chatService;
+
+    // 스터디방 필터별 검색
+    public Page<Study> getStudies(StudySearchRequest request) {
+        PageRequest pageRequest = PageRequest.of(
+                request.getPage(),
+                request.getSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt") // 최신순 정렬
+        );
+
+        // 전체 조회인 경우
+        if (request.isAllStudies()) {
+            return studyRepository.findStudiesWithFilters(
+                    null, null, null, null, pageRequest
+            );
+        }
+        // 필터 조회인 경우
+        return studyRepository.findStudiesWithFilters(
+                request.getLocationId(),
+                request.getIsOnline(),
+                request.getType(),
+                request.getIsOpened(),
+                pageRequest
+        );
+    }
+
+    // 전체 스터디 조회
+    public Page<Study> getAllStudies(StudySearchRequest request) {
+        PageRequest pageRequest = PageRequest.of(
+                request.getPage(),
+                request.getSize(),
+                Sort.by(Sort.Direction.DESC, "id") // 최신순 정렬
+        );
+        return studyRepository.findAllStudies(pageRequest);
+    }
+
+    // 단일 스터디 상세 조회
+    public Study getStudy(Long id) {
+        return studyRepository.findByIdWithLeader(id)
+                .orElseThrow(() -> new IllegalArgumentException("Study not found with id: " + id));
+    }
+
+
 
     // 스터디방 생성
     public Study createStudy(StudyCreateRequest request) {


### PR DESCRIPTION
✅ 스터디 목록 조회 (페이징)
- 전체 조회 기능 (all)
예시 -> http://localhost:8080/studies/all?page=1&size=10

- 필터 검색 기능 
예시 -> http://localhost:8080/studies?type=PROJECT&isOpened=true&page=0&size=10
    - 지역별 검색
    - 온라인 여부 검색
    - 현재 운영중인 스터디로 검색
    - 스터디 타입 검색

- 스터디 상세 조회 ({study_id})


