### PR TITLE
Feat: 소셜 로그인 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/src/main/java/com/sweetme/back/auth/controller/APIRefreshController.java
+++ b/src/main/java/com/sweetme/back/auth/controller/APIRefreshController.java
@@ -87,14 +87,12 @@ public class APIRefreshController {
         Map<String, Object> newClaims = new HashMap<>();
 
         String email = (String) claims.get("email");
-        String password = (String) claims.get("password");
         String nickname = (String) claims.get("nickname");
         LoginType loginType = LoginType.valueOf((String) claims.get("loginType"));
         UserStatus status = UserStatus.valueOf((String) claims.get("status"));
         UserRole role = UserRole.valueOf((String) claims.get("role"));
 
         newClaims.put("email", email);
-        newClaims.put("password", password);
         newClaims.put("nickname", nickname);
         newClaims.put("loginType", loginType);
         newClaims.put("status", status);

--- a/src/main/java/com/sweetme/back/auth/controller/CustomControllerAdvice.java
+++ b/src/main/java/com/sweetme/back/auth/controller/CustomControllerAdvice.java
@@ -1,11 +1,14 @@
 package com.sweetme.back.auth.controller;
 
 import com.sweetme.back.common.exception.CustomJWTException;
+import com.sweetme.back.common.exception.SocialLoginException;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestControllerAdvice
@@ -18,5 +21,15 @@ public class CustomControllerAdvice {
         String message = e.getMessage();
 
         return ResponseEntity.ok().body(Map.of("error", message));
+    }
+
+    @ExceptionHandler(SocialLoginException.class)
+    public ResponseEntity<Map<String, Object>> handleSocialLoginException(SocialLoginException e) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", "INVALID_SOCIAL_LOGIN");
+        response.put("message", e.getMessage());
+        response.put("existingLoginType", e.getExistingLoginType());
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 }

--- a/src/main/java/com/sweetme/back/auth/controller/SocialController.java
+++ b/src/main/java/com/sweetme/back/auth/controller/SocialController.java
@@ -5,9 +5,11 @@ import com.sweetme.back.auth.service.UserService;
 import com.sweetme.back.common.util.JWTUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestController
@@ -17,12 +19,57 @@ public class SocialController {
 
     private final UserService userService;
 
-    @GetMapping("/auth/login/kakao")
-    public Map<String, Object> getUserFromKakao(String accessToken) {
+    @GetMapping("/auth/login/{social}")
+    public Map<String, Object> getUserFromSocial(@PathVariable String social, String accessToken) {
 
+        log.info("social: " + social);
         log.info("access Token: " + accessToken);
 
-        AuthUserDTO authUserDTO = userService.getKakaoUser(accessToken);
+        AuthUserDTO authUserDTO = userService.getSocialUser(social, accessToken);
+
+        Map<String, Object> claims = authUserDTO.getClaims();
+
+        String jwtAccessToken = JWTUtil.generateToken(claims, 10);
+        String jwtRefreshToken = JWTUtil.generateToken(claims, 60 * 24);
+
+        claims.put("accessToken", jwtAccessToken);
+        claims.put("refreshToken", jwtRefreshToken);
+
+        return claims;
+    }
+
+    @PostMapping("/auth/login/naver")
+    public Map<String, Object> getNaverUser(@RequestBody Map<String, String> request) {
+        String grantType = request.get("grant_type");
+        String clientId = request.get("client_id");
+        String clientSecret = request.get("client_secret");
+        String code = request.get("code");
+        String state = request.get("state");
+
+        String access_token_url = "https://nid.naver.com/oauth2.0/token";
+        String params = "grant_type=" + grantType
+                + "&client_id=" + clientId
+                + "&client_secret=" + clientSecret
+                + "&code=" + code
+                + "&state=" + state;
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<String> entity = new HttpEntity<>(params, headers);
+        ResponseEntity<LinkedHashMap> response = restTemplate.exchange(access_token_url, HttpMethod.POST, entity, LinkedHashMap.class);
+
+        log.info("response: " +response);
+
+        LinkedHashMap<String, String> bodyMap = response.getBody();
+        log.info("bodyMap: " + bodyMap);
+
+        String accessToken = bodyMap.get("access_token");
+        log.info("accessToken: " + accessToken);
+
+        // UserService 이용
+        AuthUserDTO authUserDTO = userService.getSocialUser("naver", accessToken);
 
         Map<String, Object> claims = authUserDTO.getClaims();
 

--- a/src/main/java/com/sweetme/back/auth/controller/SocialController.java
+++ b/src/main/java/com/sweetme/back/auth/controller/SocialController.java
@@ -1,0 +1,37 @@
+package com.sweetme.back.auth.controller;
+
+import com.sweetme.back.auth.dto.AuthUserDTO;
+import com.sweetme.back.auth.service.UserService;
+import com.sweetme.back.common.util.JWTUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+public class SocialController {
+
+    private final UserService userService;
+
+    @GetMapping("/auth/login/kakao")
+    public Map<String, Object> getUserFromKakao(String accessToken) {
+
+        log.info("access Token: " + accessToken);
+
+        AuthUserDTO authUserDTO = userService.getKakaoUser(accessToken);
+
+        Map<String, Object> claims = authUserDTO.getClaims();
+
+        String jwtAccessToken = JWTUtil.generateToken(claims, 10);
+        String jwtRefreshToken = JWTUtil.generateToken(claims, 60 * 24);
+
+        claims.put("accessToken", jwtAccessToken);
+        claims.put("refreshToken", jwtRefreshToken);
+
+        return claims;
+    }
+}

--- a/src/main/java/com/sweetme/back/auth/domain/User.java
+++ b/src/main/java/com/sweetme/back/auth/domain/User.java
@@ -48,7 +48,17 @@ public class User extends BaseEntity {
     private String password;
 
     public enum LoginType {
-        EMAIL, KAKAO, NAVER
+        EMAIL("이메일"), KAKAO("카카오"), NAVER("네이버");
+
+        private final String displayName;
+
+        LoginType(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
     }
 
     public enum UserStatus {

--- a/src/main/java/com/sweetme/back/auth/domain/User.java
+++ b/src/main/java/com/sweetme/back/auth/domain/User.java
@@ -44,7 +44,7 @@ public class User extends BaseEntity {
     @Builder.Default
     private UserRole role = UserRole.ROLE_USER;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     public enum LoginType {

--- a/src/main/java/com/sweetme/back/auth/dto/AuthUserDTO.java
+++ b/src/main/java/com/sweetme/back/auth/dto/AuthUserDTO.java
@@ -1,0 +1,69 @@
+package com.sweetme.back.auth.dto;
+
+import com.sweetme.back.auth.domain.User.LoginType;
+import com.sweetme.back.auth.domain.User.UserRole;
+import com.sweetme.back.auth.domain.User.UserStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@ToString
+public class AuthUserDTO extends User {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private LoginType loginType;
+    private UserStatus status;
+    private UserRole role;
+
+    public AuthUserDTO(Long id, String email, String password, String nickname,
+                       LoginType loginType, UserStatus status, UserRole role) {
+        super(email, password, Collections.singleton(new SimpleGrantedAuthority(role.name())));
+
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.loginType = loginType;
+        this.status = status;
+        this.role = role;
+    }
+
+    // JWT 생성 시 사용
+    public Map<String, Object> getClaims() {
+
+        Map<String, Object> dataMap = new HashMap<>();
+
+        dataMap.put("id", id);
+        dataMap.put("email", email);
+        dataMap.put("nickname", nickname);
+        dataMap.put("loginType", loginType);
+        dataMap.put("status", status);
+        dataMap.put("role", role);
+
+        return dataMap;
+    }
+
+    // claims 로부터 UserDTO 생성
+    public static AuthUserDTO fromClaims(Map<String, Object> claims) {
+
+        Long id = (Long) claims.get("id");
+        String email = (String) claims.get("email");
+        String nickname = (String) claims.get("nickname");
+        LoginType loginType = LoginType.valueOf((String) claims.get("loginType"));
+        UserStatus status = UserStatus.valueOf((String) claims.get("status"));
+        UserRole role = UserRole.valueOf((String) claims.get("role"));
+
+        return new AuthUserDTO(id, email, null, nickname, loginType, status, role);
+
+    }
+}
+

--- a/src/main/java/com/sweetme/back/auth/dto/UserDTO.java
+++ b/src/main/java/com/sweetme/back/auth/dto/UserDTO.java
@@ -16,53 +16,27 @@ import static com.sweetme.back.auth.domain.User.*;
 @Getter
 @Setter
 @ToString
-public class UserDTO extends User {
+public class UserDTO{
 
+    private Long id;
     private String email;
-    private String password;
     private String nickname;
-    private LoginType loginType;
     private UserStatus status;
     private UserRole role;
 
-    public UserDTO(String email, String password, String nickname,
-                    LoginType loginType, UserStatus status, UserRole role) {
-        super(email, password, Collections.singleton(new SimpleGrantedAuthority(role.name())));
+    public static UserDTO from(com.sweetme.back.auth.domain.User user) {
+        /*
+        * public static LocationDTO from(Location location) {
+        if (location == null) return null;
 
-        this.email = email;
-        this.password = password;
-        this.nickname = nickname;
-        this.loginType = loginType;
-        this.status = status;
-        this.role = role;
+        LocationDTO dto = new LocationDTO();
+        dto.setId(location.getId());
+        dto.setName(location.getName());
+        dto.setType(location.getType());
+        return dto;
     }
+        * */
 
-    // JWT 생성 시 사용
-    public Map<String, Object> getClaims() {
-
-        Map<String, Object> dataMap = new HashMap<>();
-
-        dataMap.put("email", email);
-        dataMap.put("password", password);
-        dataMap.put("nickname", nickname);
-        dataMap.put("loginType", loginType);
-        dataMap.put("status", status);
-        dataMap.put("role", role);
-
-        return dataMap;
-    }
-
-    // claims 로부터 UserDTO 생성
-    public static UserDTO fromClaims(Map<String, Object> claims) {
-
-        String email = (String) claims.get("email");
-        String password = (String) claims.get("password");
-        String nickname = (String) claims.get("nickname");
-        LoginType loginType = LoginType.valueOf((String) claims.get("loginType"));
-        UserStatus status = UserStatus.valueOf((String) claims.get("status"));
-        UserRole role = UserRole.valueOf((String) claims.get("role"));
-
-        return new UserDTO(email, password, nickname, loginType, status, role);
-
+        return null;
     }
 }

--- a/src/main/java/com/sweetme/back/auth/dto/UserDTO.java
+++ b/src/main/java/com/sweetme/back/auth/dto/UserDTO.java
@@ -25,18 +25,15 @@ public class UserDTO{
     private UserRole role;
 
     public static UserDTO from(com.sweetme.back.auth.domain.User user) {
-        /*
-        * public static LocationDTO from(Location location) {
-        if (location == null) return null;
+        if (user == null) return null;
 
-        LocationDTO dto = new LocationDTO();
-        dto.setId(location.getId());
-        dto.setName(location.getName());
-        dto.setType(location.getType());
-        return dto;
-    }
-        * */
+        UserDTO userDTO = new UserDTO();
+        userDTO.setId(user.getId());
+        userDTO.setEmail(user.getEmail());
+        userDTO.setNickname(user.getNickname());
+        userDTO.setStatus(user.getStatus());
+        userDTO.setRole(user.getRole());
 
-        return null;
+        return userDTO;
     }
 }

--- a/src/main/java/com/sweetme/back/auth/repository/UserRepository.java
+++ b/src/main/java/com/sweetme/back/auth/repository/UserRepository.java
@@ -2,8 +2,12 @@ package com.sweetme.back.auth.repository;
 
 import com.sweetme.back.auth.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     User getUserByEmail(String email);
+
+    @Query("select u from User u where u.email = :email")
+    User findUserByEmail(String email);
 }

--- a/src/main/java/com/sweetme/back/auth/service/APILoginSuccessHandler.java
+++ b/src/main/java/com/sweetme/back/auth/service/APILoginSuccessHandler.java
@@ -2,6 +2,7 @@ package com.sweetme.back.auth.service;
 
 import com.google.gson.Gson;
 import com.sweetme.back.auth.domain.User;
+import com.sweetme.back.auth.dto.AuthUserDTO;
 import com.sweetme.back.auth.dto.UserDTO;
 import com.sweetme.back.common.util.JWTUtil;
 import jakarta.servlet.ServletException;
@@ -26,9 +27,9 @@ public class APILoginSuccessHandler implements AuthenticationSuccessHandler {
         log.info(authentication);
         log.info("--------------------------------");
 
-        UserDTO userDTO = (UserDTO) authentication.getPrincipal();
+        AuthUserDTO authUserDTO = (AuthUserDTO) authentication.getPrincipal();
 
-        Map<String, Object> claims = userDTO.getClaims();
+        Map<String, Object> claims = authUserDTO.getClaims();
 
         String accessToken = JWTUtil.generateToken(claims, 10); // 10분
         String refreshToken = JWTUtil.generateToken(claims, 60 * 24); // 24시간

--- a/src/main/java/com/sweetme/back/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/sweetme/back/auth/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.sweetme.back.auth.service;
 
 import com.sweetme.back.auth.domain.User;
+import com.sweetme.back.auth.dto.AuthUserDTO;
 import com.sweetme.back.auth.dto.UserDTO;
 import com.sweetme.back.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,8 @@ public class CustomUserDetailsService implements UserDetailsService {
             throw new UsernameNotFoundException("Not Found");
         }
 
-        UserDTO userDTO = new UserDTO(
+        AuthUserDTO authUserDTO = new AuthUserDTO(
+                user.getId(),
                 user.getEmail(),
                 user.getPassword(),
                 user.getNickname(),
@@ -37,8 +39,8 @@ public class CustomUserDetailsService implements UserDetailsService {
                 user.getRole()
         );
 
-        log.info(userDTO);
+        log.info(authUserDTO);
 
-        return userDTO;
+        return authUserDTO;
     }
 }

--- a/src/main/java/com/sweetme/back/auth/service/JWTCheckFilter.java
+++ b/src/main/java/com/sweetme/back/auth/service/JWTCheckFilter.java
@@ -2,6 +2,7 @@ package com.sweetme.back.auth.service;
 
 import com.google.gson.Gson;
 import com.sweetme.back.auth.domain.User;
+import com.sweetme.back.auth.dto.AuthUserDTO;
 import com.sweetme.back.auth.dto.UserDTO;
 import com.sweetme.back.common.util.JWTUtil;
 import jakarta.servlet.FilterChain;
@@ -99,15 +100,16 @@ public class JWTCheckFilter extends OncePerRequestFilter {
             log.info("JWT claims: " + claims);
 
             // claims 로부터 UserDTO 생성
-            UserDTO userDTO = UserDTO.fromClaims(claims);
+            AuthUserDTO authUserDTO = AuthUserDTO.fromClaims(claims);
 
             log.info("----------------------------------");
-            log.info(userDTO);
-            log.info(userDTO.getAuthorities());
+            log.info(authUserDTO);
+            log.info(authUserDTO.getAuthorities());
 
             // JWT 토큰에서 추출한 사용자 정보로 인증 객체를 생성
+            // 이미 토큰의 유효성은 검증되었기 때문에 인증정보에는 비밀번호 불필요
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                            userDTO, userDTO.getPassword(), Collections.singleton(new SimpleGrantedAuthority(userDTO.getRole().name())));
+                    authUserDTO, authUserDTO.getPassword(), Collections.singleton(new SimpleGrantedAuthority(authUserDTO.getRole().name())));
 
             // SecurityContext 에 인증 정보 저장 => 컨트롤러나 서비스 계층에서 권한 검증시 사용
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);

--- a/src/main/java/com/sweetme/back/auth/service/JWTCheckFilter.java
+++ b/src/main/java/com/sweetme/back/auth/service/JWTCheckFilter.java
@@ -53,7 +53,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
 
         // /auth 경로 처리
         if (path.startsWith("/auth/")) {
-            if (path.equals("/auth/login")) {
+            if (path.startsWith("/auth/login")) {
                 return true;
             }
             if (path.equals("/auth/refresh")) {

--- a/src/main/java/com/sweetme/back/auth/service/UserService.java
+++ b/src/main/java/com/sweetme/back/auth/service/UserService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public interface UserService {
 
-    AuthUserDTO getKakaoUser(String accessToken);
+    AuthUserDTO getSocialUser(String social, String accessToken);
 
     default AuthUserDTO entityToDTO(User user) {
 

--- a/src/main/java/com/sweetme/back/auth/service/UserService.java
+++ b/src/main/java/com/sweetme/back/auth/service/UserService.java
@@ -1,0 +1,26 @@
+package com.sweetme.back.auth.service;
+
+import com.sweetme.back.auth.domain.User;
+import com.sweetme.back.auth.dto.AuthUserDTO;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface UserService {
+
+    AuthUserDTO getKakaoUser(String accessToken);
+
+    default AuthUserDTO entityToDTO(User user) {
+
+        AuthUserDTO dto = new AuthUserDTO(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                user.getNickname(),
+                user.getLoginType(),
+                user.getStatus(),
+                user.getRole()
+        );
+
+        return dto;
+    }
+}

--- a/src/main/java/com/sweetme/back/auth/service/UserServiceImpl.java
+++ b/src/main/java/com/sweetme/back/auth/service/UserServiceImpl.java
@@ -27,27 +27,31 @@ public class UserServiceImpl implements UserService{
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public AuthUserDTO getKakaoUser(String accessToken) {
+    public AuthUserDTO getSocialUser(String social, String accessToken) {
 
-        String email = getEmailFromKakaoAccessToken(accessToken);
+
+        String email = switch (social.toLowerCase()) {
+            case "kakao" -> getEmailFromKakaoAccessToken(accessToken);
+            case "naver" -> getEmailFromNaverAccessToken(accessToken);
+            default -> throw new IllegalArgumentException("Unsupported social login type: " + social);
+        };
+
         log.info("email: " + email);
 
         User user = userRepository.findUserByEmail(email);
 
         if (user == null) { // 회원이 아니었다면
             log.info("신규 회원입니다.");
-            User kakaoUser = makeSocialUser(email);
-            kakaoUser.setLoginType(User.LoginType.KAKAO);
-            userRepository.save(kakaoUser);
+            User newUser = makeSocialUser(email);
+            newUser.setLoginType(User.LoginType.valueOf(social.toUpperCase()));
+            userRepository.save(newUser);
 
-            AuthUserDTO kakaoAuthUserDTO = entityToDTO(kakaoUser);
-            return kakaoAuthUserDTO;
+            return entityToDTO(newUser);
         }
 
         // 기존 회원일 경우
         log.info("기존 회원입니다.");
-        AuthUserDTO authUserDTO = entityToDTO(user);
-        return authUserDTO;
+        return entityToDTO(user);
     }
 
     private String getEmailFromKakaoAccessToken(String accessToken) {
@@ -89,6 +93,47 @@ public class UserServiceImpl implements UserService{
         log.info("kakaoAccount: " + kakaoAccount);
 
         return kakaoAccount.get("email");
+    }
+
+    private String getEmailFromNaverAccessToken(String accessToken) {
+
+        String naverGetUserURL = "https://openapi.naver.com/v1/nid/me";
+
+        // access token 유무 다시 확인
+        if (accessToken == null) {
+            throw new RuntimeException("Access Token is null");
+        }
+
+        // REST API 템플릿 객체
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // 요청문 객체
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        UriComponents uriBuilder = UriComponentsBuilder.fromHttpUrl(naverGetUserURL).build();
+
+        ResponseEntity<LinkedHashMap> response = restTemplate.exchange(
+                uriBuilder.toString(), // path
+                HttpMethod.GET, // method
+                entity, // request object
+                LinkedHashMap.class // response type
+        );
+
+        log.info("response: " + response);
+
+        LinkedHashMap<String, LinkedHashMap> bodyMap = response.getBody();
+
+        log.info("----------------------------");
+        log.info("bodyMap: " + bodyMap);
+
+        LinkedHashMap<String, String> naverAccount = bodyMap.get("response");
+        log.info("naverAccount: " + naverAccount);
+
+        return naverAccount.get("email");
     }
 
     private String makeTempPassword() {

--- a/src/main/java/com/sweetme/back/auth/service/UserServiceImpl.java
+++ b/src/main/java/com/sweetme/back/auth/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import ch.qos.logback.core.joran.conditional.IfAction;
 import com.sweetme.back.auth.domain.User;
 import com.sweetme.back.auth.dto.AuthUserDTO;
 import com.sweetme.back.auth.repository.UserRepository;
+import com.sweetme.back.common.exception.SocialLoginException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpEntity;
@@ -17,6 +18,8 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.LinkedHashMap;
+
+import static com.sweetme.back.auth.domain.User.*;
 
 @Service
 @RequiredArgsConstructor
@@ -37,16 +40,25 @@ public class UserServiceImpl implements UserService{
         };
 
         log.info("email: " + email);
+        LoginType currentLoginType = LoginType.valueOf(social.toUpperCase());
 
         User user = userRepository.findUserByEmail(email);
 
         if (user == null) { // 회원이 아니었다면
             log.info("신규 회원입니다.");
             User newUser = makeSocialUser(email);
-            newUser.setLoginType(User.LoginType.valueOf(social.toUpperCase()));
+            newUser.setLoginType(LoginType.valueOf(social.toUpperCase()));
             userRepository.save(newUser);
 
             return entityToDTO(newUser);
+        }
+
+        // 기존 회원이고 로그인 타입이 다를 경우
+        if (!user.getLoginType().equals(currentLoginType)) {
+            String message = String.format("이 메일은 %s 계정으로 가입되어 있습니다. %s로 로그인해 주세요.",
+                    user.getLoginType().name().toLowerCase(),
+                    user.getLoginType().getDisplayName());
+            throw new SocialLoginException(user.getLoginType(), message);
         }
 
         // 기존 회원일 경우
@@ -155,12 +167,12 @@ public class UserServiceImpl implements UserService{
 
         String nickname = "소셜회원";
 
-        User user = User.builder()
+        User user = builder()
                 .email(email)
                 .password(tempPassword)
                 .nickname(nickname)
-                .status(User.UserStatus.ACTIVE)
-                .role(User.UserRole.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.ROLE_USER)
                 .build();
 
         return user;

--- a/src/main/java/com/sweetme/back/auth/service/UserServiceImpl.java
+++ b/src/main/java/com/sweetme/back/auth/service/UserServiceImpl.java
@@ -1,0 +1,123 @@
+package com.sweetme.back.auth.service;
+
+import ch.qos.logback.core.joran.conditional.IfAction;
+import com.sweetme.back.auth.domain.User;
+import com.sweetme.back.auth.dto.AuthUserDTO;
+import com.sweetme.back.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.LinkedHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class UserServiceImpl implements UserService{
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public AuthUserDTO getKakaoUser(String accessToken) {
+
+        String email = getEmailFromKakaoAccessToken(accessToken);
+        log.info("email: " + email);
+
+        User user = userRepository.findUserByEmail(email);
+
+        if (user == null) { // 회원이 아니었다면
+            log.info("신규 회원입니다.");
+            User kakaoUser = makeSocialUser(email);
+            kakaoUser.setLoginType(User.LoginType.KAKAO);
+            userRepository.save(kakaoUser);
+
+            AuthUserDTO kakaoAuthUserDTO = entityToDTO(kakaoUser);
+            return kakaoAuthUserDTO;
+        }
+
+        // 기존 회원일 경우
+        log.info("기존 회원입니다.");
+        AuthUserDTO authUserDTO = entityToDTO(user);
+        return authUserDTO;
+    }
+
+    private String getEmailFromKakaoAccessToken(String accessToken) {
+
+        String kakaoGetUserURL = "https://kapi.kakao.com/v2/user/me";
+
+        // access token 유무 다시 확인
+        if (accessToken == null) {
+            throw new RuntimeException("Access Token is null");
+        }
+
+        // REST API 템플릿 객체
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // 요청문 객체
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        UriComponents uriBuilder = UriComponentsBuilder.fromHttpUrl(kakaoGetUserURL).build();
+
+        ResponseEntity<LinkedHashMap> response = restTemplate.exchange(
+                uriBuilder.toString(), // path
+                HttpMethod.GET, // method
+                entity, // request object
+                LinkedHashMap.class // response type
+        );
+
+        log.info("response: " + response);
+
+        LinkedHashMap<String, LinkedHashMap> bodyMap = response.getBody();
+
+        log.info("----------------------------");
+        log.info("bodyMap: " + bodyMap);
+
+        LinkedHashMap<String, String> kakaoAccount = bodyMap.get("kakao_account");
+        log.info("kakaoAccount: " + kakaoAccount);
+
+        return kakaoAccount.get("email");
+    }
+
+    private String makeTempPassword() {
+
+        StringBuffer buffer = new StringBuffer();
+
+        for (int i = 0; i < 10; i++) {
+            buffer.append((char) ((int) (Math.random() * 55) + 65));
+        }
+
+        return buffer.toString();
+    }
+
+    private User makeSocialUser(String email) {
+
+        String tempPassword = makeTempPassword();
+
+        log.info("tempPassword: " + tempPassword);
+
+        String nickname = "소셜회원";
+
+        User user = User.builder()
+                .email(email)
+                .password(tempPassword)
+                .nickname(nickname)
+                .status(User.UserStatus.ACTIVE)
+                .role(User.UserRole.ROLE_USER)
+                .build();
+
+        return user;
+    }
+}

--- a/src/main/java/com/sweetme/back/common/exception/SocialLoginException.java
+++ b/src/main/java/com/sweetme/back/common/exception/SocialLoginException.java
@@ -1,0 +1,13 @@
+package com.sweetme.back.common.exception;
+
+import com.sweetme.back.auth.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SocialLoginException extends RuntimeException {
+
+    private final User.LoginType existingLoginType;
+    private final String message;
+}

--- a/src/main/java/com/sweetme/back/common/util/JWTUtil.java
+++ b/src/main/java/com/sweetme/back/common/util/JWTUtil.java
@@ -29,8 +29,7 @@ public class JWTUtil {
     // 매개변수: jwt 에 담을 claim 데이터, jwt 유효기간(분 단위)
     public static String generateToken(Map<String, Object> valueMap, int min) {
 
-        log.info("JWTUtil.key 검증------------");
-        log.info(JWTUtil.key);
+        log.info("토큰 생성 중");
 
         SecretKey key = null;
 

--- a/src/main/java/com/sweetme/back/common/util/SecurityUtil.java
+++ b/src/main/java/com/sweetme/back/common/util/SecurityUtil.java
@@ -3,6 +3,7 @@ package com.sweetme.back.common.util;
 import com.sweetme.back.auth.dto.AuthUserDTO;
 import com.sweetme.back.auth.dto.UserDTO;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -11,16 +12,30 @@ import org.springframework.stereotype.Component;
 @Log4j2
 public class SecurityUtil {
 
+    // 인증 정보에서 회원 DTO 호출
     public static UserDTO getCurrentUser() {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || !authentication.isAuthenticated()) {
+        if (authentication == null || !authentication.isAuthenticated() ||
+                authentication instanceof AnonymousAuthenticationToken) { // 익명 사용자 체크
             throw new RuntimeException("Security Context 에 인증 정보가 없습니다.");
+        }
+
+        // Principal 타입 체크 추가
+        if (!(authentication.getPrincipal() instanceof AuthUserDTO)) {
+            throw new RuntimeException("Invalid principal type");
         }
 
         AuthUserDTO authUserDTO = (AuthUserDTO) authentication.getPrincipal();
 
-        return (UserDTO) authentication.getPrincipal();
+        UserDTO userDTO = new UserDTO();
+        userDTO.setId(authUserDTO.getId());
+        userDTO.setEmail(authUserDTO.getEmail());
+        userDTO.setNickname(authUserDTO.getNickname());
+        userDTO.setStatus(authUserDTO.getStatus());
+        userDTO.setRole(authUserDTO.getRole());
+
+        return userDTO;
     }
 }

--- a/src/main/java/com/sweetme/back/common/util/SecurityUtil.java
+++ b/src/main/java/com/sweetme/back/common/util/SecurityUtil.java
@@ -1,0 +1,26 @@
+package com.sweetme.back.common.util;
+
+import com.sweetme.back.auth.dto.AuthUserDTO;
+import com.sweetme.back.auth.dto.UserDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Log4j2
+public class SecurityUtil {
+
+    public static UserDTO getCurrentUser() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new RuntimeException("Security Context 에 인증 정보가 없습니다.");
+        }
+
+        AuthUserDTO authUserDTO = (AuthUserDTO) authentication.getPrincipal();
+
+        return (UserDTO) authentication.getPrincipal();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 
 # JPA 설정
-#spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
@@ -17,4 +17,4 @@ logging.level.org.springframework.security.web=trace
 com.sweetme.jwt.secret=${JWT_SECRET_KEY}
 
 # 스프링 설정 분리(dev, prod, test)
-spring.profiles.active=dev
+spring.profiles.active=prod


### PR DESCRIPTION
### 1️⃣ 소셜 로그인 기능
- 카카오 로그인: 프론트에서 `인증코드 & 액세스 토큰` 전달 => 백에서 카카오 회원 정보 획득
- 네이버 로그인: 프론트에서 `인증코드` 전달 => 백에서 액세스 토큰&회원 정보 획득
- 사용자가 선택한 소셜 로그인 방식과 기존에 저장된 회원 로그인 타입이 다를 경우 예외 처리 및 안내

### 2️⃣ 인증회원 관련 유틸리티 기능
- User 엔티티에서 UserDTO 생성 메서드 추가
- 현재 로그인한 회원을 Security Context 에서 조회하는 메서드 추가

### 3️⃣ 인증 및 시큐리티용 회원 DTO 추가
- AuthUserDTO
