### PR TITLE
Feat : 프로필 조회 기능 추가

### DIFF
--- a/src/main/java/com/sweetme/back/chat/controller/ChatController.java
+++ b/src/main/java/com/sweetme/back/chat/controller/ChatController.java
@@ -7,6 +7,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @RestController
 @RequestMapping("/studies")
 @RequiredArgsConstructor
@@ -15,6 +20,7 @@ public class ChatController {
 
     private final ChatService chatService;
 
+    // 채팅글 페이징 처리
     @GetMapping("/{studyId}/chat")
     public ResponseEntity<Page<ChatResponseDTO>> getChatsByStudyId(
             @PathVariable Long studyId,
@@ -23,5 +29,22 @@ public class ChatController {
 
         Page<ChatResponseDTO> chats = chatService.getChatsByStudyId(studyId, page, size);
         return ResponseEntity.ok(chats);
+    }
+
+    // 채팅방 유저 프로필 조회
+    @GetMapping("/{studyId}/chat/member")
+    public ResponseEntity<List<Map<String, Long>>> getUserByStudyId(
+            @PathVariable Long studyId) {
+        List<Long> users = chatService.getUserByStudyId(studyId);
+        List<Map<String, Long>> userProfiles = new ArrayList<>();
+
+        for (Long userId : users) {
+            Map<String, Long> userProfile = new HashMap<>();
+            userProfile.put("userId", userId);  // userId를 Long으로 저장
+            userProfile.put("profileId", chatService.getProfileIdByUserId(userId));  // profileId를 Long으로 저장
+            userProfiles.add(userProfile);
+        }
+
+        return ResponseEntity.ok(userProfiles);
     }
 }

--- a/src/main/java/com/sweetme/back/chat/repository/ChatRepository.java
+++ b/src/main/java/com/sweetme/back/chat/repository/ChatRepository.java
@@ -1,12 +1,19 @@
-// ChatRepository.java
 package com.sweetme.back.chat.repository;
 
+import com.sweetme.back.auth.domain.User;
 import com.sweetme.back.chat.domain.Chat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
         Page<Chat> findByStudyIdOrderByCreatedAtDesc(Long studyId, Pageable pageable);
 
+        // user 조회
+        @Query("SELECT m.user  FROM Member m WHERE m.study.id = :studyId and m.status = 'ACCEPTED'")
+        List<User> findByStudyId(@Param("studyId") Long studyId);
 }

--- a/src/main/java/com/sweetme/back/chat/service/ChatService.java
+++ b/src/main/java/com/sweetme/back/chat/service/ChatService.java
@@ -1,13 +1,21 @@
 package com.sweetme.back.chat.service;
 
+import com.sweetme.back.auth.domain.User;
 import com.sweetme.back.chat.domain.Chat;
 import com.sweetme.back.chat.dto.ChatResponseDTO;
 import com.sweetme.back.chat.repository.ChatRepository;
+import com.sweetme.back.profile.domain.Profile;
+import com.sweetme.back.profile.repository.ProfileRepository;
+import com.sweetme.back.profile.service.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,10 +23,29 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatService {
 
     private final ChatRepository chatRepository;
+    private final ProfileService profileService;
+    private final ProfileRepository profileRepository;
 
+    // 채팅내역 페이징 조회
     public Page<ChatResponseDTO> getChatsByStudyId(Long studyId, int page, int size) {
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<Chat> chats = chatRepository.findByStudyIdOrderByCreatedAtDesc(studyId, pageRequest);
         return chats.map(ChatResponseDTO::new);
+    }
+
+    // 채팅방 유저 아이디 조회
+    public List<Long> getUserByStudyId(Long studyId) {
+        List<User> users = chatRepository.findByStudyId(studyId);
+        List<Long> usersId = new ArrayList<>();
+        for (User user : users) {
+            usersId.add(user.getId());
+        }
+        return usersId;
+    }
+
+    // 채팅방 유저 프로필아이디 조회
+    public Long getProfileIdByUserId(Long userId) {
+        Optional<Profile> profile  = profileRepository.findWithStacksByUserId(userId);
+        return profile.get().getId();
     }
 }


### PR DESCRIPTION
# ChatRepository 
## 함수명 : findByStudyId
- ### 기능: studyId를 키 값으로 Member테이블에서 Status가 Accepted인 User 리스트를 조회

- ### Input : studyId
- ### Output : List\<User\>

# ChatService
## 함수명 : getUserByStudyId
- ### 기능 : studyId를 키 값으로 User 리스트 객체에서 userId 리스트로 변환
- ### Input : studyId
- ### Output : List\<Long\>

## 함수명 : getProfileIdByUserId
- ### 기능 : userId를 키 값으로 Profile 객체에서 profileId만 반환
- ### Input : userId
- ### Output : profileId

# ChatController
## 함수명 : getUserByStudyId
- ### 기능 : "studies/{studyId}/chat/member 조회시 해당 스터디에 모든 userId와 profileId를 json형식의 리스트로 반환
- ### Input : studyId
- ### Output : userId, profileId
